### PR TITLE
fikser bug med at innholdsmeny forsvinner pga feil i beregning av høy…

### DIFF
--- a/src/templates/faktaside/Navigasjonsmeny/useDekoratorPopdownOffset.ts
+++ b/src/templates/faktaside/Navigasjonsmeny/useDekoratorPopdownOffset.ts
@@ -7,7 +7,7 @@ export function useDekoratorPopdownOffset() {
 
   useMount(() => {
     const handleScroll = () => {
-      const menuRect = document.querySelector(`[aria-label="Hovedmeny"]`)?.getBoundingClientRect();
+      const menuRect = document.getElementById('hovedmeny')?.getBoundingClientRect();
       const offset = menuRect ? menuRect.height + menuRect.top : 0;
       setOffsetTop(Math.max(offset, 0));
     };


### PR DESCRIPTION
…de på dekoratør-popdown.

dekoratøren ser ut til å ha mistet noen id'er vi brukte for å beregne høyden her. Fant ingen ny id'er å bruke, men aria-labelen "Hovedmeny" ser ut til å gjøre susen, så selecter på den.