### PR TITLE
rekursiv funksjon for å hente ut alle _updatedAt-timestamps. Da slipp…

### DIFF
--- a/gatsby-utils/createFaktasider.ts
+++ b/gatsby-utils/createFaktasider.ts
@@ -103,7 +103,7 @@ export const createFaktasider: GatsbyNode['createPages'] = async (props) => {
 export function createFaktasideContext(page: RawFaktasideData, lang: SupportedLanguage): FaktasideContext {
   const localizedPage = localizeSanityContent(page, lang) as LocalizedFaktasideData;
   const parsedInnhold = parseRichText(localizedPage.innhold);
-  const publiseringsTidspunkt = getPubliseringsTidspunkt(page, lang);
+  const publiseringsTidspunkt = getPubliseringsTidspunkt(localizedPage);
 
   return {
     ...localizedPage,

--- a/gatsby-utils/getPubliseringstidspunkt.test.ts
+++ b/gatsby-utils/getPubliseringstidspunkt.test.ts
@@ -25,6 +25,6 @@ const testData: RawFaktasideData = ({
 } as unknown) as RawFaktasideData;
 
 test('finner nyeste publiseringstidspunkt fra faktaside', () => {
-  const tidspunkt = getPubliseringsTidspunkt(testData, 'no');
+  const tidspunkt = getPubliseringsTidspunkt(testData);
   expect(tidspunkt).toEqual(updatedAtLatest);
 });

--- a/gatsby-utils/getPubliseringstidspunkt.ts
+++ b/gatsby-utils/getPubliseringstidspunkt.ts
@@ -1,14 +1,16 @@
-import { RawFaktasideData } from './createFaktasider';
 import { max } from 'date-fns';
-import { isDeltTekstReference } from '../src/utils/richTextUtils/richTextTypes';
-import { SupportedLanguage } from '../src/i18n/supportedLanguages';
 
-export function getPubliseringsTidspunkt(page: RawFaktasideData, lang: SupportedLanguage): string {
-  const delteTekster = page.innhold?.[lang]?.filter(isDeltTekstReference) || [];
-  const oppdateringsTidspunkter: string[] = [
-    ...delteTekster.map((reference) => reference.deltTekst?._updatedAt || ''),
-    page._updatedAt,
-  ];
+export function getPubliseringsTidspunkt(page): string {
+  const allUpdatedAt = getAllUpdatedAt(page);
+  return max(allUpdatedAt.map((it) => new Date(it))).toISOString();
+}
 
-  return max(oppdateringsTidspunkter.map((it) => new Date(it))).toISOString();
+function getAllUpdatedAt(value) {
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => getAllUpdatedAt(v));
+  } else if (value && typeof value === 'object') {
+    return Object.keys(value)
+      .flatMap((key) => (key === '_updatedAt' ? value[key] : getAllUpdatedAt(value[key])))
+      .filter((it) => it);
+  }
 }

--- a/src/templates/faktaside/SistOppdatert.test.tsx
+++ b/src/templates/faktaside/SistOppdatert.test.tsx
@@ -6,14 +6,14 @@ import { rawFaktasideDataMock } from '../../../__mocks__/rawFaktasideDataMock';
 
 describe('Sist oppdatert funker finfint med internasjonalisering', () => {
   test('På norsk', () => {
-    const publiseringsTidspunkt = getPubliseringsTidspunkt(rawFaktasideDataMock, 'no');
+    const publiseringsTidspunkt = getPubliseringsTidspunkt(rawFaktasideDataMock);
     const result = render(<SistOppdatert publiseringsTidspunkt={publiseringsTidspunkt} />);
 
     result.getByText(/10. juli 2020 12:54/);
   });
 
   test('På engelsk', () => {
-    const publiseringsTidspunkt = getPubliseringsTidspunkt(rawFaktasideDataMock, 'en');
+    const publiseringsTidspunkt = getPubliseringsTidspunkt(rawFaktasideDataMock);
     const result = render(<SistOppdatert publiseringsTidspunkt={publiseringsTidspunkt} />, undefined, 'en');
 
     result.getByText(/July 10th 2020 12:54/);


### PR DESCRIPTION
…er man å kjenne strukturen på innholdet men kan bare lete etter alt innhold som har et felt av typen _updatedAt. Så velger vi det seneste tidspunktet for å vise når en endring sist skjedde på den aktuelle siden