### PR TITLE
endrer ingress for å legge til rette for hurtiglenke i sammarbeid med…

### DIFF
--- a/nais/dev/vars.yaml
+++ b/nais/dev/vars.yaml
@@ -3,4 +3,5 @@ namespace: default
 team: teamdagpenger
 ingresses: |
   ingresses:
-    - https://www-q1.nav.no/arbeid
+    - https://www-q6.nav.no/arbeid/
+    - https://www-q1.nav.no/arbeid/

--- a/nais/prod/vars.yaml
+++ b/nais/prod/vars.yaml
@@ -3,4 +3,4 @@ namespace: default
 team: teamdagpenger
 ingresses: |
   ingresses:
-    - https://www.nav.no/arbeid
+    - https://www.nav.no/arbeid/


### PR DESCRIPTION
… Morten Jansrud

hurtiglenken nav.no/arbeidsledig skal gå til nav.no/arbied/no/arbeidsledig. Siden appen vår svarte på alle url'er under nav.no/arbeid* ble denne hurtiglenken også fanget opp av appen vår og skapte trøbbel.
appen svarer nå under nav.no/arbeid/* og team personbruker setter opp en redirect fra nav.no/arbeid -> nav.no/arbeid/ slik at man skal komme seg inn i appen selv om man ikke skriver / bak url'en