### PR TITLE
Fix/remove menudata fallback when page not specified in links

### DIFF
--- a/src/__tests__/404.test.tsx
+++ b/src/__tests__/404.test.tsx
@@ -19,6 +19,6 @@ describe("404-side", () => {
     const liste = result.getByRole("list");
     const lenker = within(liste).getAllByRole("link");
 
-    expect(lenker).toHaveLength(mockMenuData.sider.length + mockMenuData.lenker.length);
+    expect(lenker).toHaveLength(mockMenuData.lenker.length);
   });
 });

--- a/src/__tests__/arbeidsledig-permittert.test.tsx
+++ b/src/__tests__/arbeidsledig-permittert.test.tsx
@@ -18,7 +18,7 @@ test("Index-side inneholder lenker til undersider med beskrivelse", () => {
   const lenkeListe = result.getAllByRole("list")[0];
   const lenker = within(lenkeListe).getAllByRole("link");
 
-  expect(lenker).toHaveLength(mockMenuData.lenker.length + mockMenuData.sider.length);
+  expect(lenker).toHaveLength(mockMenuData.lenker.length); //lenker tas ikke lengre ut fra sider, men brukes for å resolve references
 
   const lenkeData2 = mockMenuData.sider[1];
   const lenkeNummer2 = result.getByTestId(`/${lenkeData2.slug}/`) as HTMLLinkElement;

--- a/src/components/BlockContent/VisFor/VisPaaSide.test.tsx
+++ b/src/components/BlockContent/VisFor/VisPaaSide.test.tsx
@@ -4,6 +4,7 @@ import { render, within } from "../../../testUtils/customized-testing-library.te
 import { Historikk } from "../../historikk/Historikk";
 import { visPaaSideTestData } from "./VisPaaSide.testdata";
 import { historikkVisPaaTestdata } from "../../historikk/historikk.testdata";
+import { visForTestDataMenuQuery } from "./visFor.testdata";
 
 describe("innhold i delt tekst merket med visPaa", () => {
   test("skal vises for alle sider dersom innholdet er merket med et tomt visPaa-array", () => {
@@ -20,7 +21,8 @@ describe("innhold i delt tekst merket med visPaa", () => {
   });
 
   test("skal vises i menyen på sider den er merket for å vises på", () => {
-    const page = render(<TestFaktaside partialFaktaside={visPaaSideTestData} />);
+    // @ts-ignore, må caste menudata til en partial av menuquerydata elns
+    const page = render(<TestFaktaside partialFaktaside={visPaaSideTestData} partialMeny={visForTestDataMenuQuery} />);
 
     const meny = page.getAllByLabelText(/innholdsfortegnelse/i)[0];
     within(meny).getByText("Vis på denne siden");
@@ -33,7 +35,8 @@ describe("innhold i delt tekst merket med visPaa", () => {
   });
 
   test("skal ikke vises i menyen på sider den ikke er merket for å vises på", () => {
-    const page = render(<TestFaktaside partialFaktaside={visPaaSideTestData} />);
+    // @ts-ignore, må caste menudata til en partial av menuquerydata elns
+    const page = render(<TestFaktaside partialFaktaside={visPaaSideTestData} partialMeny={visForTestDataMenuQuery} />);
 
     const meny = page.getAllByLabelText(/innholdsfortegnelse/i)[0];
 

--- a/src/components/BlockContent/VisFor/VisPaaSide.testdata.tsx
+++ b/src/components/BlockContent/VisFor/VisPaaSide.testdata.tsx
@@ -1,5 +1,6 @@
 import { createDeltTekstBlock, createSanityBlock, translated } from "../../../testUtils/createSanityBlock";
 import { faktaSideMockQueryData } from "../../../testUtils/faktaSideMockQueryData";
+import { visForTestDataMenuQuery } from "./visFor.testdata";
 
 const testId = faktaSideMockQueryData.faktaside.id;
 

--- a/src/components/BlockContent/VisFor/visFor.test.tsx
+++ b/src/components/BlockContent/VisFor/visFor.test.tsx
@@ -8,7 +8,7 @@ import { translated } from "../../../testUtils/createSanityBlock";
 import parseRichText from "../../../utils/richTextUtils/parser/parseRichText";
 import { TestId } from "../../../utils/test-ids";
 
-const { innhold } = visForTestData;
+const { innhold, menuData } = visForTestData;
 const {
   bolkStudent,
   bolkPermittert,
@@ -30,9 +30,13 @@ describe("visFor-logikk", () => {
   });
 
   test("Hvis man filtrer på student vises ikke permittertinnhold", async () => {
-    const result = render(<TestFaktaside innhold={innhold} />);
+    // @ts-ignore, må caste menudata til en partial av menuquerydata elns
+    const result = render(<TestFaktaside innhold={innhold} partialMeny={menuData} />);
 
     toggleFilter(result, /Student/i);
+
+    const meny = result.getAllByLabelText(/innholdsfortegnelse/i)[0];
+    expect(within(meny).queryByText(bolkPermittert)).toBeNull();
 
     const mainContent = result.getByRole("main");
     expect(within(mainContent).queryByText(innholdPermittert)).toBeNull();
@@ -40,9 +44,6 @@ describe("visFor-logikk", () => {
 
     within(mainContent).getByText(innholdStudent);
     within(mainContent).getByLabelText(bolkStudent);
-
-    const meny = result.getAllByLabelText(/innholdsfortegnelse/i)[0];
-    expect(within(meny).queryByText(bolkPermittert)).toBeNull();
 
     within(meny).getByText(bolkStudent);
   });

--- a/src/components/BlockContent/VisFor/visFor.testdata.tsx
+++ b/src/components/BlockContent/VisFor/visFor.testdata.tsx
@@ -1,4 +1,4 @@
-import { createSanityBlock } from "../../../testUtils/createSanityBlock";
+import { createSanityBlock, translated } from "../../../testUtils/createSanityBlock";
 import { VisForSituasjon } from "./VisFor";
 
 const bolkStudent = "Bolk som bare vises for student";
@@ -7,7 +7,7 @@ const bolkForAlle = "Overskrift som vises for alle";
 const innholdStudent = "Innhold som vises for student";
 const innholdPermittert = "Innhold som vises for permittert";
 const innholdForAlle = "Innhold som vises for alle";
-const bolkSkjulForPermittertOgKonkurs = "Bolk som skjules for permittert";
+const bolkSkjulForPermittertOgKonkurs = "Bolk som skjules for permittert og konkurs";
 
 const data = [
   createSanityBlock(bolkForAlle, { style: "h2" }),
@@ -28,6 +28,21 @@ const data = [
   createSanityBlock("Innhold som skjules for permittert"),
 ];
 
+export const visForTestDataMenuQuery = {
+  lenker: [{ _type: "reference", referenceType: "faktaSide", pageId: "testId" }],
+  sider: [
+    {
+      slug: "test",
+      title: translated("Test side"),
+      visSprakversjon: {
+        no: true,
+      },
+      beskrivelse: translated("her tester vi ting"),
+      id: "testId",
+    },
+  ],
+};
+
 export const visForTestData = {
   tekster: {
     innholdPermittert,
@@ -39,6 +54,7 @@ export const visForTestData = {
     bolkSkjulForPermittertOgKonkurs,
   },
   innhold: data,
+  menuData: visForTestDataMenuQuery,
 };
 
 export const mockVisForKonverteringstabell: VisForSituasjon[] = [

--- a/src/components/BlockContent/draft/Draft.test.tsx
+++ b/src/components/BlockContent/draft/Draft.test.tsx
@@ -4,6 +4,7 @@ import { SanityContent } from "../../sanity-content/SanityContent";
 import { render, within } from "../../../testUtils/customized-testing-library.test.utils";
 import { draftTestdata } from "./Draft.testdata";
 import TestFaktaside from "../../../testUtils/TestFaktaside";
+import { visForTestDataMenuQuery } from "../VisFor/visFor.testdata";
 
 describe("utkast", () => {
   const parsedInnhold = parseRichText(draftTestdata);
@@ -31,7 +32,8 @@ describe("utkast", () => {
   });
 
   test("Dersom en hel overskrift er merket med utkast skal ikke bolken vises i meny", () => {
-    const result = render(<TestFaktaside innhold={draftTestdata} />);
+    // @ts-ignore, må caste menudata til en partial av menuquerydata elns
+    const result = render(<TestFaktaside innhold={draftTestdata} partialMeny={visForTestDataMenuQuery} />);
 
     const desktopInnholdsfortegnelse = result.getAllByLabelText(/innholdsfortegnelse/i)[0];
 

--- a/src/components/faktaside/Meny/Meny.test.tsx
+++ b/src/components/faktaside/Meny/Meny.test.tsx
@@ -16,7 +16,7 @@ describe("Navigasjonsmeny", () => {
     const sideliste = within(desktopNavigasjonsmeny).getAllByRole("list")[0];
     const lenker = within(sideliste).getAllByRole("listitem");
 
-    expect(lenker).toHaveLength(mockMenuData.sider.length + mockMenuData.lenker.length);
+    expect(lenker).toHaveLength(mockMenuData.lenker.length);
   });
 
   test("lenkene er bygd opp riktig", () => {

--- a/src/components/faktaside/content/KortFortalt.test.tsx
+++ b/src/components/faktaside/content/KortFortalt.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, within } from "../../../testUtils/customized-testing-library.test.utils";
 import TestFaktaside from "../../../testUtils/TestFaktaside";
 import { createSanityBlock, translated } from "../../../testUtils/createSanityBlock";
+import { visForTestDataMenuQuery } from "../../BlockContent/VisFor/visFor.testdata";
 
 describe("kortFortalt", () => {
   test("vises ikke om det ikke finnes innhold i kort fortalt", () => {
@@ -11,7 +12,10 @@ describe("kortFortalt", () => {
   });
 
   test("vises ikke i innholdsmeny om det ikke finnes innhold i kort fortalt", () => {
-    const result = render(<TestFaktaside partialFaktaside={{ kortFortalt: translated([]) }} />);
+    const result = render(
+      // @ts-ignore, må caste menudata til en partial av menuquerydata elns
+      <TestFaktaside partialFaktaside={{ kortFortalt: translated([]) }} partialMeny={visForTestDataMenuQuery} />
+    );
 
     const meny = result.getAllByLabelText(/Innholdsfortegnelse/i)[0];
     expect(within(meny).queryByLabelText(/Kort fortalt/)).toBeFalsy();
@@ -35,7 +39,8 @@ describe("kortFortalt", () => {
       <TestFaktaside
         partialFaktaside={{
           kortFortalt: translated([createSanityBlock("Litt innhold")]),
-        }}
+        }} // @ts-ignore, må caste menudata til en partial av menuquerydata elns
+        partialMeny={visForTestDataMenuQuery}
       />
     );
 

--- a/src/components/faktaside/content/Snarveier.test.tsx
+++ b/src/components/faktaside/content/Snarveier.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, within } from "../../../testUtils/customized-testing-library.test.utils";
 import TestFaktaside from "../../../testUtils/TestFaktaside";
 import { Snarvei } from "../../../sanity/groq/forside/forsideQuery";
+import { visForTestDataMenuQuery } from "../../BlockContent/VisFor/visFor.testdata";
 
 const id = "testId";
 
@@ -21,7 +22,8 @@ describe("snarveier", () => {
   });
 
   test("vises ikke i innholdsmeny om det ikke finnes innhold i snarveier", () => {
-    const result = render(<TestFaktaside partialOppsett={{ snarveier: [] }} />);
+    // @ts-ignore, må caste menudata til en partial av menuquerydata elns
+    const result = render(<TestFaktaside partialOppsett={{ snarveier: [] }} partialMeny={visForTestDataMenuQuery} />);
 
     const meny = result.getAllByLabelText(/Innholdsfortegnelse/i)[0];
     expect(within(meny).queryByLabelText(/Snarveier/)).toBeFalsy();
@@ -35,7 +37,14 @@ describe("snarveier", () => {
   });
 
   test("vises i meny dersom det finnes innhold i snarveier", () => {
-    const result = render(<TestFaktaside partialFaktaside={{ id }} partialOppsett={{ snarveier: [snarvei] }} />);
+    const result = render(
+      <TestFaktaside
+        partialFaktaside={{ id }}
+        partialOppsett={{ snarveier: [snarvei] }}
+        // @ts-ignore, må caste menudata til en partial av menuquerydata elns
+        partialMeny={visForTestDataMenuQuery}
+      />
+    );
 
     const meny = result.getAllByLabelText(/Innholdsfortegnelse/i)[0];
     within(meny).getByText(/Snarveier/i);

--- a/src/sanity/groq/menu/mockMenuData.ts
+++ b/src/sanity/groq/menu/mockMenuData.ts
@@ -8,6 +8,8 @@ export const mockMenuData = {
       tittel: "Ekstern lenke",
       beskrivelse: "Lenke til en ekstern side",
     },
+    { _type: "reference", referenceType: "faktaSide", pageId: "random-id-permittert" },
+    { _type: "reference", referenceType: "faktaSide", pageId: "-89eddf21-6b78-5f89-8d1f-7f5f8ebfe735" },
   ],
   sider: [
     {
@@ -17,7 +19,7 @@ export const mockMenuData = {
         no: true,
       },
       beskrivelse: translated("Har du blitt permittert?"),
-      id: "random-id-permittert",
+      id: "-89eddf21-6b78-5f89-8d1f-7f5f8ebfe735",
     },
     {
       slug: "arbeidsledig",

--- a/src/sanity/groq/menu/mockMenuData.ts
+++ b/src/sanity/groq/menu/mockMenuData.ts
@@ -19,7 +19,7 @@ export const mockMenuData = {
         no: true,
       },
       beskrivelse: translated("Har du blitt permittert?"),
-      id: "-89eddf21-6b78-5f89-8d1f-7f5f8ebfe735",
+      id: "random-id-permittert",
     },
     {
       slug: "arbeidsledig",

--- a/src/sanity/groq/menu/parseMenuData.ts
+++ b/src/sanity/groq/menu/parseMenuData.ts
@@ -34,12 +34,7 @@ export function parseMenuData(data: MenuQueryData, lang: SupportedLanguage): Men
       : lenke
   );
 
-  const pageNotInSortedLinks = (page: TranslatedMenuDataSide) =>
-    !sortedMenuLinks.some((link) => link._type === "menylenkeIntern" && link.pageId === page.id);
-  // Sørger for at alle interne sider havner i menyen selv om de ikke eksplisitt er lagt til i menyen i Sanity. Sørger for at vi ikke har noen "skjulte" sider.
-  const unsortedInternalLinks = sider.filter(pageNotInSortedLinks).map((page) => createInternalLinkData(page, lang));
-
-  return [...sortedMenuLinks, ...unsortedInternalLinks];
+  return [...sortedMenuLinks];
 }
 
 function isInternLenke(lenke: MenyLenkeRaw): lenke is MenylenkeInternRaw {


### PR DESCRIPTION
temp, tests still failing. probably have to do in some way to the way the menu system is loaded in (i think), it now requires every test to specifically inject their testpage into the testmenu