### PR TITLE
Kjør tester og bygg i parallell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ jobs:
   jest-test:
     name: Jest tests
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -37,7 +36,6 @@ jobs:
   cypress-test:
     name: Cypress tests
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Man kan like gjerne kjøre alle testene og bygget av docker imaget i parallell. Da får man en raskere feedback loop og ting raskere ut i prod.